### PR TITLE
Add copying of existing dependencies

### DIFF
--- a/link_manifests/index.js
+++ b/link_manifests/index.js
@@ -8,5 +8,5 @@ rp.dependencies = rp.dependencies?.filter( d => !d.uuid ) ?? []
 bp.dependencies.push( { "uuid": rp.header.uuid, "version": rp.header.version } )
 rp.dependencies.push( { "uuid": bp.header.uuid, "version": bp.header.version } )
 
-fs.writeFileSync("RP/manifest.json", JSON.stringify(rp))
-fs.writeFileSync("BP/manifest.json", JSON.stringify(bp))
+fs.writeFileSync("RP/manifest.json", JSON.stringify(rp, null, 2))
+fs.writeFileSync("BP/manifest.json", JSON.stringify(bp, null, 2))

--- a/link_manifests/index.js
+++ b/link_manifests/index.js
@@ -3,8 +3,10 @@ const fs = require("fs")
 const bp = JSON.parse(fs.readFileSync("BP/manifest.json"))
 const rp = JSON.parse(fs.readFileSync("RP/manifest.json"))
 
-bp.dependencies = [ { "uuid": rp.header.uuid, "version": rp.header.version } ]
-rp.dependencies = [ { "uuid": bp.header.uuid, "version": bp.header.version } ]
+bp.dependencies = bp.dependencies?.filter( d => !d.uuid ) ?? []
+rp.dependencies = rp.dependencies?.filter( d => !d.uuid ) ?? []
+bp.dependencies.push( { "uuid": rp.header.uuid, "version": rp.header.version } )
+rp.dependencies.push( { "uuid": bp.header.uuid, "version": bp.header.version } )
 
 fs.writeFileSync("RP/manifest.json", JSON.stringify(rp))
 fs.writeFileSync("BP/manifest.json", JSON.stringify(bp))


### PR DESCRIPTION
Prevents deletion of scripting module dependencies in bp manifest.